### PR TITLE
next() as argument

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -3,7 +3,7 @@ var path = require('path');
 
 module.exports = function(user) {
   //send verification email after registration
-  user.afterRemote('create', function(context, user) {
+  user.afterRemote('create', function(context, user, next) {
     console.log('> user.afterRemote triggered');
 
     var options = {


### PR DESCRIPTION
It looks like the next function was not passed as an argument in the afterRemote callback function.

I'm fairly sure next() needs to be called for the success case as well for user.afterRemote to complete?