### PR TITLE
next undefined in user.js throws TypeError

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -16,7 +16,7 @@ module.exports = function(user) {
       user: user
     };
 
-    user.verify(options, function(err, response, next) {
+    user.verify(options, function(err, response) {
       if (err) return next(err);
 
       console.log('> verification email sent:', response);


### PR DESCRIPTION
Issue https://github.com/strongloop/loopback-example-user-management/issues/13 hasn't been resolved, in case an "err" occurs I still get an TypeError because next is  undefined. 

```javascript
if (err) return next(err);
^
TypeError: undefined is not a function
```
I fixed this issue by deleting next from the callback parameters while calling user.verify:
```javascript
user.verify(options, function(err, response) {
...
}
```
This is correct because of the following reason:
- Line 405: https://github.com/strongloop/loopback/blob/master/common/models/user.js 
the fn only gets called with 1 parameter, so next would be _undefined_.
- We want to use the next callback from Line 6 as suggested in the solution here https://github.com/strongloop/loopback-example-user-management/commit/3a8a26642cc74ac0b5f98434828b84e44b6af847
- The err is then passed to the correct callback
